### PR TITLE
Screw Tilt Calibration For the Silicon Mod

### DIFF
--- a/1 - Primary Configuration Files/einsy-rambo.cfg
+++ b/1 - Primary Configuration Files/einsy-rambo.cfg
@@ -19,22 +19,23 @@ sample_retract_dist: 1.0
 resolution: 0.25
 
 [bed_screws]
+# Nozzle above the screws
 screw1: 13,6
 screw1_name: Front Left
 screw2: 13,115
-screw2_name: Front Center
+screw2_name: Center Left
 screw3: 13,210
-screw3_name: Front Right
+screw3_name: Back Left
 
 screw4: 123,6
-screw4_name: Center Left
+screw4_name: Front Center
 screw5: 123,210
-screw5_name: Center Right
+screw5_name: Back Center
 
 screw6: 228,6
-screw6_name: Back Left
+screw6_name: Front Right
 screw7: 228,115
-screw7_name: Back Center
+screw7_name: Center Right
 screw8: 228,210
 screw8_name: Back Right
 

--- a/1 - Primary Configuration Files/einsy-rambo.cfg
+++ b/1 - Primary Configuration Files/einsy-rambo.cfg
@@ -39,27 +39,29 @@ screw7_name: Center Right
 screw8: 228,210
 screw8_name: Back Right
 
-[screws_tilt_adjust]
-# PINDA should be above the screw
-screw1: 102,104
-screw1_name: Center (Fixed)
-screw2: 0,0
-screw2_name: Front Left
-screw3: 100,1
-screw3_name: Front Center
-screw4: 203,1
-screw4_name: Front Right
-screw5: 0,110
-screw5_name: Center Left
-screw6: 203,99
-screw6_name: Center Right
-screw7: 0,205
-screw7_name: Back Left
-screw8: 100,205
-screw8_name: Back Center
-screw9: 203,205
-screw9_name: Back Right
-screw_thread: CCW-M3  # Prusa screws from the top, so it is inverted from the default of CW-M3
+### Uncomment this if you use the nylock or silicon mod onn your bed
+### to enable semi-automatic tilt adjustment.
+# [screws_tilt_adjust]
+# # PINDA should be above the screw
+# screw1: 102,104
+# screw1_name: Center (Fixed)
+# screw2: 0,0
+# screw2_name: Front Left
+# screw3: 100,1
+# screw3_name: Front Center
+# screw4: 203,1
+# screw4_name: Front Right
+# screw5: 0,110
+# screw5_name: Center Left
+# screw6: 203,99
+# screw6_name: Center Right
+# screw7: 0,205
+# screw7_name: Back Left
+# screw8: 100,205
+# screw8_name: Back Center
+# screw9: 203,205
+# screw9_name: Back Right
+# screw_thread: CCW-M3  # Prusa screws from the top, so it is inverted from the default of CW-M3
 
 [extruder]
 nozzle_diameter: 0.400

--- a/1 - Primary Configuration Files/einsy-rambo.cfg
+++ b/1 - Primary Configuration Files/einsy-rambo.cfg
@@ -38,6 +38,28 @@ screw7_name: Back Center
 screw8: 228,210
 screw8_name: Back Right
 
+[screws_tilt_adjust]
+# PINDA should be above the screw
+screw1: 102,104
+screw1_name: Center (Fixed)
+screw2: 0,0
+screw2_name: Front Left
+screw3: 100,1
+screw3_name: Front Center
+screw4: 203,1
+screw4_name: Front Right
+screw5: 0,110
+screw5_name: Center Left
+screw6: 203,99
+screw6_name: Center Right
+screw7: 0,205
+screw7_name: Back Left
+screw8: 100,205
+screw8_name: Back Center
+screw9: 203,205
+screw9_name: Back Right
+screw_thread: CCW-M3  # Prusa screws from the top, so it is inverted from the default of CW-M3
+
 [extruder]
 nozzle_diameter: 0.400
 filament_diameter: 1.750


### PR DESCRIPTION
Not sure if you want to include this as it does assume using the silicon bed level mod, however maybe including it commented out may be appropriate:

Configure screw tilt calibration in Klipper.  This allows users to more or less automatically adjust bed screws when used in combination with silicon tubing.