### PR TITLE
PRINT_STOP Stepper Behaviors

### DIFF
--- a/1 - Primary Configuration Files/macros.cfg
+++ b/1 - Primary Configuration Files/macros.cfg
@@ -36,7 +36,7 @@ gcode:
 gcode:
     #SET_SKEW CLEAR=1
     _TOOLHEAD_PARK_PAUSE_CANCEL    ; Park
-    M84    ; Disable steppers
+    M84 X Y E    ; Disable steppers
     TURN_OFF_HEATERS    ; Disable heaters
     M106 S0     ; Disable fans
     BED_MESH_CLEAR    ; Clear bed mesh


### PR DESCRIPTION
By default, Prusa machines leave the z stepper enabled at the end of the print.  This is useful to be able to jog the carriage out of the way manually.  