### PR TITLE
Switch to minimum_cruise_ratio

### DIFF
--- a/1 - Primary Configuration Files/printer.template.cfg
+++ b/1 - Primary Configuration Files/printer.template.cfg
@@ -15,7 +15,7 @@ kinematics: cartesian
 ## MK3.5 Settings based on MK3.5 IS PrusaSlicer factory profile machine limits
 max_velocity: 300
 max_accel: 4000
-max_accel_to_decel: 2000
+minimum_cruise_ratio:0.5
 max_z_velocity: 12
 max_z_accel: 200
 


### PR DESCRIPTION
As `max_accel_to_decel` would soon be deprecated[[1]](https://docs.mainsail.xyz/faq/klipper_warnings/deprecated_option#max_accel_to_decel), I am opening this pull request to switch to `minimum_cruise_ratio`

There is no official explanation to how to switch, but I followed the comments of the [annoucement](https://old.reddit.com/r/klippers/comments/1bery4m/max_accel_to_decel_changed_to_min_cruise_ratio/). The `minimum_cruise_ratio` should be 0.5.