### PR TITLE
Fix hardcoded serial path and typos in config files

### DIFF
--- a/1 - Primary Configuration Files/adxlmcu-BTT.cfg
+++ b/1 - Primary Configuration Files/adxlmcu-BTT.cfg
@@ -3,9 +3,12 @@
 # You will first need to build and flash the firmware onto the BTT board.
 # Follow the instructions in the user manual here: https://github.com/bigtreetech/ADXL345
 #
+# IMPORTANT: After flashing, find your board's unique serial path by running:
+#   ls /dev/serial/by-id/*
+# Then replace the placeholder serial below with your board's actual path.
 
 [mcu adxl]
-serial: /dev/serial/by-id/usb-Klipper_rp2040_5044506120C1481C-if00
+serial: /dev/serial/by-id/REPLACE_WITH_YOUR_BTT_ADXL345_SERIAL
 
 [adxl345]
 cs_pin: adxl:gpio9

--- a/1 - Primary Configuration Files/printer.template.cfg
+++ b/1 - Primary Configuration Files/printer.template.cfg
@@ -38,7 +38,8 @@ z_offset = 0.000 #Regular bed sheet
 #z_offset = 0.000 #Smooth bed sheet, add/delete/edit as needed
 
 [mcu]
-serial: /dev/ttyACM0 # If you are using RPI via USB connection to printer
+# Use a stable serial path. Find yours by running: ls /dev/serial/by-id/*
+serial: /dev/serial/by-id/REPLACE_WITH_YOUR_PRINTER_SERIAL
 #serial: /dev/serial0 # If you are using internal RPI serial port, not recommended.
 restart_method: command
 
@@ -54,7 +55,7 @@ restart_method: command
 
 ### HOTEND, BED and EXTRUDER - 
 
-## Possible Hotends - This config file is intended for stock Prusa components. If you are using a non-stock hotend or extruder, please see the example configuration files in the dz0ny repository, upon which this project is based. These are not guarunteed to be correct, but a good start.
+## Possible Hotends - This config file is intended for stock Prusa components. If you are using a non-stock hotend or extruder, please see the example configuration files in the dz0ny repository, upon which this project is based. These are not guaranteed to be correct, but a good start.
 ## 1) Stock V6
 ## 2) Dragon Standard Flow
 ## 3) Rapido
@@ -81,8 +82,8 @@ pid_kd = 110.045
 
 
 ##TUNE ME
-##Pressuer Advance Section - Perform this tuning for your individual machine: https://ellis3dp.com/Print-Tuning-Guide/articles/index_pressure_advance.html
-##ENTER THE PA VALUE VALUE IN SLICER FILAMENT SETTINGS - In Filament Settings Custom G Code section (allows you to print with different PA for each filament, more flexibile than here).
+##Pressure Advance Section - Perform this tuning for your individual machine: https://ellis3dp.com/Print-Tuning-Guide/articles/index_pressure_advance.html
+##ENTER THE PA VALUE IN SLICER FILAMENT SETTINGS - In Filament Settings Custom G Code section (allows you to print with different PA for each filament, more flexible than here).
 ##You may also enter a set a global value here if you want, but it's not recommended.
 #pressure_advance: 0.05
 


### PR DESCRIPTION
## Summary

- **adxlmcu-BTT.cfg**: Replace hardcoded serial path (`usb-Klipper_rp2040_5044506120C1481C-if00`) with a clear placeholder and add instructions for finding the correct path. The hardcoded path causes confusion for new users who don't realize they need to change it.
- **printer.template.cfg**: Fix typos ("Pressuer" → "Pressure", "guarunteed" → "guaranteed"), and recommend using the stable `/dev/serial/by-id/` path instead of `/dev/ttyACM0` which can change between reboots.

## Test plan

- [ ] Verify adxlmcu-BTT.cfg loads correctly in Klipper with a user-supplied serial path
- [ ] Verify printer.template.cfg loads correctly with a user-supplied serial path
- [ ] Confirm no other references to the old hardcoded serial exist