### PR TITLE
feat: add Marlin/Prusa G-code compatibility macros

### DIFF
--- a/1 - Primary Configuration Files/macros.cfg
+++ b/1 - Primary Configuration Files/macros.cfg
@@ -215,6 +215,35 @@ gcode:
     # Start nozzle heating
     M104 S190
 
+# Marlin compatibility macros - handles Marlin-style G-code from slicers
+[gcode_macro M204]
+rename_existing: M204.1
+gcode:
+    {% set S = params.S|default(printer.configfile.settings.printer.max_accel)|int %}
+    {% set P = params.P|default(S)|int %}
+    {% set T = params.T|default(S)|int %}
+    SET_VELOCITY_LIMIT ACCEL={[P,T]|min}
+
+[gcode_macro M205]
+gcode:
+    {% set X = params.X|default(5)|float %}
+    {% set Y = params.Y|default(5)|float %}
+    SET_VELOCITY_LIMIT SQUARE_CORNER_VELOCITY={[X,Y]|min}
+
+# M572 - Prusa firmware pressure advance (S parameter = advance factor)
+[gcode_macro M572]
+gcode:
+    {% if params.S is defined %}
+        SET_PRESSURE_ADVANCE ADVANCE={params.S}
+    {% endif %}
+
+# M900 - Marlin linear advance (K parameter = advance factor)
+[gcode_macro M900]
+gcode:
+    {% if params.K is defined %}
+        SET_PRESSURE_ADVANCE ADVANCE={params.K}
+    {% endif %}
+
 # Color change or filament runout
 [gcode_macro M600]
 description: Color change or filament runout


### PR DESCRIPTION
## Summary
- Adds M204, M205, M572, and M900 macros to `macros.cfg`
- Translates Marlin/Prusa firmware G-codes to Klipper equivalents
- Allows slicers configured for Marlin (PrusaSlicer, Orca Slicer) to work without manual G-code changes

### Macros added:
| G-code | Purpose | Klipper equivalent |
|--------|---------|-------------------|
| M204 | Set acceleration (P/T/S) | `SET_VELOCITY_LIMIT ACCEL=` |
| M205 | Set square corner velocity (X/Y) | `SET_VELOCITY_LIMIT SQUARE_CORNER_VELOCITY=` |
| M572 | Prusa pressure advance (S) | `SET_PRESSURE_ADVANCE ADVANCE=` |
| M900 | Marlin linear advance (K) | `SET_PRESSURE_ADVANCE ADVANCE=` |

Closes #13

## Test plan
- [x] Verified M900 K parameter correctly maps to SET_PRESSURE_ADVANCE
- [x] Verified M572 S parameter correctly maps to SET_PRESSURE_ADVANCE
- [x] Tested with Orca Slicer generated G-code on Prusa MK3S+ with Klipper