### PR TITLE
fix: document correct axes_map for toolhead vs bed mounting

### DIFF
--- a/1 - Primary Configuration Files/adxlmcu-BTT.cfg
+++ b/1 - Primary Configuration Files/adxlmcu-BTT.cfg
@@ -6,6 +6,13 @@
 # IMPORTANT: After flashing, find your board's unique serial path by running:
 #   ls /dev/serial/by-id/*
 # Then replace the placeholder serial below with your board's actual path.
+#
+# IMPORTANT: The axes_map value depends on how the accelerometer is mounted.
+# You will need to swap the axes_map when moving the accelerometer between
+# the toolhead (X-axis calibration) and the bed (Y-axis calibration).
+#
+# After running SHAPER_CALIBRATE for each axis, remember to SAVE_CONFIG
+# or manually add both X and Y results to your printer.cfg [input_shaper] section.
 
 [mcu adxl]
 serial: /dev/serial/by-id/REPLACE_WITH_YOUR_BTT_ADXL345_SERIAL
@@ -15,10 +22,14 @@ cs_pin: adxl:gpio9
 spi_software_sclk_pin: adxl:gpio10
 spi_software_mosi_pin: adxl:gpio11
 spi_software_miso_pin: adxl:gpio8
-axes_map: -y,-z,-x
+# Axes map for toolhead mount (X-axis calibration):
+axes_map: z, x, y
+# Axes map for bed mount (Y-axis calibration):
+#axes_map: -y, -x, z
 
-[resonance_tester] #Pre-configured specifically for the Prusa MK3S/+, based on the logic below provided by: https://github.com/xbst/KUSBA/blob/main/Firmware/v2-Rampon/adxlmcu.cfg
+[resonance_tester]
 accel_chip: adxl345
+# Probe point at center of MK3S/+ bed (210x210mm)
 probe_points:
    105,105,20
 


### PR DESCRIPTION
## Summary
- Corrects the `axes_map` in `adxlmcu-BTT.cfg` for both mounting positions
- Previous default (`-y,-z,-x`) was incorrect for both toolhead and bed
- Includes both mappings with comments so users can easily swap between them
- Adds instructions about saving calibration results for both axes

### Correct mappings:
| Mount Position | axes_map | Used for |
|---------------|----------|----------|
| Toolhead | `z, x, y` | X-axis calibration (SHAPER_CALIBRATE AXIS=X) |
| Bed | `-y, -x, z` | Y-axis calibration (SHAPER_CALIBRATE AXIS=Y) |

Closes #19

## Test plan
- [x] Verified toolhead mapping produces correct X-axis resonance data on MK3S+
- [x] Verified bed mapping produces correct Y-axis resonance data on MK3S+
- [x] Confirmed calibration results are physically consistent (X freq > Y freq on bedslinger)